### PR TITLE
Entry Processor

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -1,6 +1,7 @@
 package mount
 
 import (
+	"context"
 	"errors"
 )
 
@@ -45,8 +46,12 @@ type Info struct {
 }
 
 // GetDiskFormat uses 'lsblk' to see if the given disk is unformatted.
-func GetDiskFormat(disk string) (string, error) {
-	return getDiskFormat(disk)
+func GetDiskFormat(
+	ctx context.Context,
+	disk string,
+	processor EntryProcessorFunc) (string, error) {
+
+	return getDiskFormat(ctx, disk, processor)
 }
 
 // FormatAndMount uses unix utils to format and mount the given disk.
@@ -96,13 +101,20 @@ func Unmount(target string) error {
 //
 // * Darwin hosts parse the output of the "mount" command to obtain
 //   mount information.
-func GetMounts() ([]*Info, error) {
-	return getMounts()
+func GetMounts(
+	ctx context.Context,
+	processor EntryProcessorFunc) ([]Info, error) {
+
+	return getMounts(ctx, processor)
 }
 
 // GetDevMounts returns a slice of all mounts for dev
-func GetDevMounts(dev string) ([]*Info, error) {
-	return getDevMounts(dev)
+func GetDevMounts(
+	ctx context.Context,
+	dev string,
+	processor EntryProcessorFunc) ([]Info, error) {
+
+	return getDevMounts(ctx, dev, processor)
 }
 
 func contains(list []string, item string) bool {

--- a/mount/mount_unix_test.go
+++ b/mount/mount_unix_test.go
@@ -1,0 +1,65 @@
+// +build linux darwin
+
+package mount_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/thecodeteam/gocsi/mount"
+)
+
+func TestMountArgs(t *testing.T) {
+	tests := []struct {
+		src    string
+		tgt    string
+		fst    string
+		opts   []string
+		result string
+	}{
+		{
+			src:    "localhost:/data",
+			tgt:    "/mnt",
+			fst:    "nfs",
+			result: "-t nfs localhost:/data /mnt",
+		},
+		{
+			src:    "localhost:/data",
+			tgt:    "/mnt",
+			result: "localhost:/data /mnt",
+		},
+		{
+			src:    "localhost:/data",
+			tgt:    "/mnt",
+			fst:    "nfs",
+			opts:   []string{"tcp", "vers=4"},
+			result: "-t nfs -o tcp,vers=4 localhost:/data /mnt",
+		},
+		{
+			src:    "/dev/disk/mydisk",
+			tgt:    "/mnt/mydisk",
+			fst:    "xfs",
+			opts:   []string{"ro", "noatime", "ro"},
+			result: "-t xfs -o ro,noatime /dev/disk/mydisk /mnt/mydisk",
+		},
+		{
+			src:    "/dev/sdc",
+			tgt:    "/mnt",
+			opts:   []string{"rw", "", "noatime"},
+			result: "-o rw,noatime /dev/sdc /mnt",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(st *testing.T) {
+			st.Parallel()
+			opts := mount.MakeMountArgs(tt.src, tt.tgt, tt.fst, tt.opts)
+			optsStr := strings.Join(opts, " ")
+			if optsStr != tt.result {
+				t.Errorf("Formatting of mount args incorrect, got: %s want: %s",
+					optsStr, tt.result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch updates the GoCSI mount package to support custom entry processors when reading mount information. This change is not backwards-compatible.