### PR TITLE
Idempotency Interceptor Refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,11 @@ $(GOCSI_A): $(CSI_GOSRC) *.go
 ########################################################################
 GINKGO := ./ginkgo
 GINKGO_PKG := ./vendor/github.com/onsi/ginkgo/ginkgo
+GINKGO_SECS := 20
+ifeq (true,$(TRAVIS))
+GINKGO_SECS := 30
+endif
+GINKGO_RUN_OPTS := --slowSpecThreshold=$(GINKGO_SECS) -randomizeAllSpecs -p
 $(GINKGO):
 	go build -o "$@" $(GINKGO_PKG)
 
@@ -204,7 +209,7 @@ ifneq (true,$(TRAVIS))
 test:  build
 endif
 test: | $(GINKGO)
-	$(GINKGO) -v . || test "$$?" -eq "197"
+	$(GINKGO) $(GINKGO_RUN_OPTS) . || test "$$?" -eq "197"
 
 
 ########################################################################

--- a/interceptors_server_request_id_injector.go
+++ b/interceptors_server_request_id_injector.go
@@ -7,11 +7,17 @@ import (
 	"google.golang.org/grpc"
 )
 
-var requestIDVal uint64
+type serverRequestIDInjector struct {
+	requestIDVal uint64
+}
 
-// ServerRequestIDInjector is a unary server interceptor that injects
+// NewServerRequestIDInjector returns a new server interceptor that injects
 // request contexts with a unique request ID.
-func ServerRequestIDInjector(
+func NewServerRequestIDInjector() grpc.UnaryServerInterceptor {
+	return (&serverRequestIDInjector{}).handle
+}
+
+func (i *serverRequestIDInjector) handle(
 	ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
@@ -21,6 +27,6 @@ func ServerRequestIDInjector(
 		context.WithValue(
 			ctx,
 			requestIDKey,
-			atomic.AddUint64(&requestIDVal, 1)),
+			atomic.AddUint64(&i.requestIDVal, 1)),
 		req)
 }

--- a/mock/service/idemp.go
+++ b/mock/service/idemp.go
@@ -8,25 +8,36 @@ import (
 	"github.com/thecodeteam/gocsi/csi"
 )
 
-func (s *service) GetVolumeName(
+func (s *service) GetVolumeID(
 	ctx xctx.Context,
-	id string) (string, error) {
+	name string) (string, error) {
 
-	i, v := s.findVol("id", id)
+	i, v := s.findVol("name", name)
 	if i < 0 {
 		return "", nil
 	}
-	return v.Attributes["name"], nil
+	return v.Id, nil
 }
 
 func (s *service) GetVolumeInfo(
 	ctx xctx.Context,
-	name string) (*csi.VolumeInfo, error) {
+	id, name string) (*csi.VolumeInfo, error) {
 
-	i, v := s.findVol("name", name)
+	var (
+		i = -1
+		v csi.VolumeInfo
+	)
+	if id != "" {
+		i, v = s.findVol("id", id)
+	}
+	if i < 0 && name != "" {
+		i, v = s.findVol("name", name)
+	}
+
 	if i < 0 {
 		return nil, nil
 	}
+
 	return &v, nil
 }
 

--- a/trylock.go
+++ b/trylock.go
@@ -16,16 +16,16 @@ type MutexWithTryLock interface {
 }
 
 type mutex struct {
-	c chan int
+	c chan struct{}
 }
 
 // NewMutexWithTryLock returns a new mutex that implements TryLock.
 func NewMutexWithTryLock() MutexWithTryLock {
-	return &mutex{c: make(chan int, 1)}
+	return &mutex{c: make(chan struct{}, 1)}
 }
 
 func (m *mutex) Lock() {
-	m.c <- 1
+	m.c <- struct{}{}
 }
 
 func (m *mutex) Unlock() {
@@ -35,7 +35,7 @@ func (m *mutex) Unlock() {
 func (m *mutex) TryLock(timeout time.Duration) bool {
 	timer := time.NewTimer(timeout)
 	select {
-	case m.c <- 1:
+	case m.c <- struct{}{}:
 		timer.Stop()
 		return true
 	case <-time.After(timeout):


### PR DESCRIPTION
This patch refactors the idempotency interceptor to use twin locking domains based on the volume name and ID. Additionally, the interceptor has been optimized to no longer require name lookups for each operation.