### PR TITLE
Don't log response if response is nil

### DIFF
--- a/interceptors.go
+++ b/interceptors.go
@@ -3,7 +3,28 @@ package gocsi
 import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
+	"github.com/thecodeteam/gocsi/csi"
 )
+
+var nilResponses = map[string]interface{}{
+	CreateVolume:               (*csi.CreateVolumeResponse)(nil),
+	DeleteVolume:               (*csi.DeleteVolumeResponse)(nil),
+	ControllerPublishVolume:    (*csi.ControllerPublishVolumeResponse)(nil),
+	ControllerUnpublishVolume:  (*csi.ControllerUnpublishVolumeResponse)(nil),
+	ValidateVolumeCapabilities: (*csi.ValidateVolumeCapabilitiesResponse)(nil),
+	ListVolumes:                (*csi.ListVolumesResponse)(nil),
+	GetCapacity:                (*csi.GetCapacityResponse)(nil),
+	ControllerGetCapabilities:  (*csi.ControllerGetCapabilitiesResponse)(nil),
+	ControllerProbe:            (*csi.ControllerProbeResponse)(nil),
+	GetSupportedVersions:       (*csi.GetSupportedVersionsResponse)(nil),
+	GetPluginInfo:              (*csi.GetPluginInfoResponse)(nil),
+	GetNodeID:                  (*csi.GetNodeIDResponse)(nil),
+	NodePublishVolume:          (*csi.NodePublishVolumeResponse)(nil),
+	NodeUnpublishVolume:        (*csi.NodeUnpublishVolumeResponse)(nil),
+	NodeProbe:                  (*csi.NodeProbeResponse)(nil),
+	NodeGetCapabilities:        (*csi.NodeGetCapabilitiesResponse)(nil),
+}
 
 // ChainUnaryClient chains one or more unary, client interceptors
 // together into a left-to-right series that can be provided to a
@@ -103,4 +124,19 @@ func ChainUnaryServer(
 		}
 		return c(ctx, req)
 	}
+}
+
+func isResponseNil(method string, rep interface{}) bool {
+	// Determine whether or not the resposne is nil. Otherwise it
+	// will no longer be possible to perform a nil equality check on the
+	// response to the interface{} rules for nil comparison. For more info
+	// please see https://golang.org/doc/faq#nil_error and
+	// https://github.com/grpc/grpc-go/issues/532.
+	if rep == nil {
+		return true
+	}
+	if nilRep := nilResponses[method]; rep == nilRep {
+		return true
+	}
+	return false
 }

--- a/interceptors_logger.go
+++ b/interceptors_logger.go
@@ -142,7 +142,7 @@ func (s *loggingInterceptor) handle(
 	}
 
 	// Print the response data if it is set.
-	if rep != nil {
+	if !isResponseNil(method, rep) {
 		rprintReqOrRep(w, rep)
 	}
 	fmt.Fprintln(s.opts.repw, w.String())

--- a/interceptors_spec_validator.go
+++ b/interceptors_spec_validator.go
@@ -11,25 +11,6 @@ import (
 	"github.com/thecodeteam/gocsi/csi"
 )
 
-var nilResponses = map[string]interface{}{
-	CreateVolume:               (*csi.CreateVolumeResponse)(nil),
-	DeleteVolume:               (*csi.DeleteVolumeResponse)(nil),
-	ControllerPublishVolume:    (*csi.ControllerPublishVolumeResponse)(nil),
-	ControllerUnpublishVolume:  (*csi.ControllerUnpublishVolumeResponse)(nil),
-	ValidateVolumeCapabilities: (*csi.ValidateVolumeCapabilitiesResponse)(nil),
-	ListVolumes:                (*csi.ListVolumesResponse)(nil),
-	GetCapacity:                (*csi.GetCapacityResponse)(nil),
-	ControllerGetCapabilities:  (*csi.ControllerGetCapabilitiesResponse)(nil),
-	ControllerProbe:            (*csi.ControllerProbeResponse)(nil),
-	GetSupportedVersions:       (*csi.GetSupportedVersionsResponse)(nil),
-	GetPluginInfo:              (*csi.GetPluginInfoResponse)(nil),
-	GetNodeID:                  (*csi.GetNodeIDResponse)(nil),
-	NodePublishVolume:          (*csi.NodePublishVolumeResponse)(nil),
-	NodeUnpublishVolume:        (*csi.NodeUnpublishVolumeResponse)(nil),
-	NodeProbe:                  (*csi.NodeProbeResponse)(nil),
-	NodeGetCapabilities:        (*csi.NodeGetCapabilitiesResponse)(nil),
-}
-
 // SpecValidatorOption configures the spec validator interceptor.
 type SpecValidatorOption func(*specValidatorOpts)
 
@@ -255,20 +236,15 @@ func (s *specValidator) handle(
 
 	// Determine whether or not the response is nil. Otherwise it
 	// will no longer be possible to perform a nil equality check on the
-	// response to the interface{} rules for nil comparison. For more info
-	// please see https://golang.org/doc/faq#nil_error and
-	// https://github.com/grpc/grpc-go/issues/532.
-	var isNilRep bool
-	if nilRep := nilResponses[method]; rep == nilRep {
-		isNilRep = true
-	}
+	// response to the interface{} rules for nil comparison.
+	isNilRep := isResponseNil(method, rep)
 
 	// Handle possible non-zero successful exit codes.
-	if err := s.handleResponseError(method, err); err != nil {
+	if err2 := s.handleResponseError(method, err); err2 != nil {
 		if isNilRep {
-			return nil, err
+			return nil, err2
 		}
-		return rep, err
+		return nil, err2
 	}
 
 	// If the response is nil then go ahead and return a nil value


### PR DESCRIPTION
If the interface coming into the req or response logger was nil, a crash
occured during reflection. Make sure the reflected value is valid before
continuing.

Example crash:
```sh
panic: reflect: call of reflect.Value.Type on zero Value

goroutine 40 [running]:
reflect.Value.Type(0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/travis/.go/1.9.0/src/reflect/value.go:1688 +0x1a3
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.rprintReqOrRep(0xb05c80, 0xc42013c7e0, 0x849340, 0x0)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors_logger.go:158 +0xac
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.(*loggingInterceptor).handle(0xc420180080, 0xb0dac0, 0xc4201769c0, 0x8c50a6, 0x1c, 0x86f2e0, 0xc42040ac40, 0xc4201d76b0, 0x46e3c2, 0x0, ...)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors_logger.go:144 +0x56a
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.(*loggingInterceptor).handleServer(0xc420180080, 0xb0dac0, 0xc4201769c0, 0x86f2e0, 0xc42040ac40, 0xc42040ac60, 0xc42040acc0, 0x7f18e5d2e9b8, 0x40c45b, 0xc4201d77c8, ...)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors_logger.go:79 +0xea
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.(*loggingInterceptor).(github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.handleServer)-fm(0xb0dac0, 0xc4201769c0, 0x86f2e0, 0xc42040ac40, 0xc42040ac60, 0xc42040acc0, 0x10, 0x809fc0, 0xc4201c0580, 0xc42037a710)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors_logger.go:54 +0x73
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.ChainUnaryServer.func2.1.1(0xb0dac0, 0xc4201769c0, 0x86f2e0, 0xc42040ac40, 0x4, 0x0, 0x0, 0x4101f7)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors.go:97 +0x66
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.(*requestIDInjector).handleServer(0xc420186088, 0xb0dac0, 0xc4201769c0, 0x86f2e0, 0xc42040ac40, 0xc42040ac60, 0xc42040ace0, 0x7f18e5d2e9b8, 0x0, 0xc4201d78c0, ...)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors_request_id.go:84 +0x2b1
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.(*requestIDInjector).(github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.handleServer)-fm(0xb0dac0, 0xc4201769c0, 0x86f2e0, 0xc42040ac40, 0xc42040ac60, 0xc42040ace0, 0xc42040ac60, 0x846240, 0x1, 0xc42037a700)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors_request_id.go:25 +0x73
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.ChainUnaryServer.func2.1.1(0xb0dac0, 0xc4201769c0, 0x86f2e0, 0xc42040ac40, 0xc42040ac20, 0xc4201d7968, 0x410958, 0x20)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors.go:97 +0x66
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi.ChainUnaryServer.func2(0xb0dac0, 0xc4201769c0, 0x86f2e0, 0xc42040ac40, 0xc42040ac60, 0xc42040aca0, 0x432294, 0xc4201d79e0, 0x410958, 0x50)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/interceptors.go:104 +0xf8
github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/csi._Controller_DeleteVolume_Handler(0x89b340, 0xc420192000, 0xb0dac0, 0xc4201769c0, 0xc4202d6500, 0xc4201800e0, 0x0, 0x0, 0xc42001f300, 0x46)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/github.com/thecodeteam/gocsi/csi/csi.pb.go:2033 +0x16d
github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc42019a000, 0xb0fd60, 0xc420076840, 0xc420174100, 0xc420176390, 0xb492d8, 0x0, 0x0, 0x0)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc/server.go:843 +0xab4
github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc.(*Server).handleStream(0xc42019a000, 0xb0fd60, 0xc420076840, 0xc420174100, 0x0)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc/server.go:1040 +0x1528
github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc4203845f0, 0xc42019a000, 0xb0fd60, 0xc420076840, 0xc420174100)
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc/server.go:589 +0x9f
created by github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/travis/go/src/github.com/thecodeteam/csi-scaleio/vendor/google.golang.org/grpc/server.go:587 +0xa1
```