### PR TITLE
Additional CSC Updates

### DIFF
--- a/csc/cmd/controller_create_volume.go
+++ b/csc/cmd/controller_create_volume.go
@@ -20,7 +20,7 @@ var createVolume struct {
 
 var createVolumeCmd = &cobra.Command{
 	Use:     "create-volume",
-	Aliases: []string{"new", "create"},
+	Aliases: []string{"n", "c", "new", "create"},
 	Short:   `invokes the rpc "CreateVolume"`,
 	Example: `
 CREATING MULTIPLE VOLUMES
@@ -91,36 +91,27 @@ func init() {
 		"The limit to the size of the volume in bytes")
 
 	createVolumeCmd.Flags().Var(
-		&createVolume.caps,
-		"cap",
-		volumeCapabilityDesc)
-
-	createVolumeCmd.Flags().Var(
 		&createVolume.params,
 		"params",
-		paramsDesc)
-
-	createVolumeCmd.Flags().BoolVar(
-		&root.withRequiresCreds,
-		"with-requires-credentials",
-		false,
-		withRequiresCredsDesc)
-
-	createVolumeCmd.Flags().BoolVar(
-		&root.withRequiresVolumeAttributes,
-		"with-requires-attributes",
-		false,
-		withRequiresRepAttribsDesc)
-
-	createVolumeCmd.Flags().BoolVar(
-		&root.withSuccessCreateVolumeAlreadyExists,
-		"with-success-already-exists",
-		false,
-		`Treats an AlreadyExists error code as a successful response.
-        Enabling this option also enables --with-spec-validation.`)
-}
-
-const paramsDesc = `One or more key/value pairs may be specified to send with
+		`One or more key/value pairs may be specified to send with
         the request as its Parameters field:
 
-            --params key1=val1,key2=val2 --params=key3=val3`
+            --params key1=val1,key2=val2 --params=key3=val3`)
+
+	flagVolumeCapabilities(createVolumeCmd.Flags(), &createVolume.caps)
+
+	flagWithSuccessAlreadyExists(
+		createVolumeCmd.Flags(),
+		&root.withSuccessCreateVolumeAlreadyExists,
+		"")
+
+	flagWithRequiresCreds(
+		createVolumeCmd.Flags(),
+		&root.withRequiresCreds,
+		"")
+
+	flagWithRequiresAttribs(
+		createVolumeCmd.Flags(),
+		&root.withRequiresVolumeAttributes,
+		"")
+}

--- a/csc/cmd/controller_delete_volume.go
+++ b/csc/cmd/controller_delete_volume.go
@@ -12,7 +12,7 @@ import (
 
 var deleteVolumeCmd = &cobra.Command{
 	Use:     "delete-volume",
-	Aliases: []string{"rm", "delete"},
+	Aliases: []string{"d", "rm", "del", "delete"},
 	Short:   `invokes the rpc "DeleteVolume"`,
 	Example: `
 USAGE
@@ -49,16 +49,13 @@ USAGE
 func init() {
 	controllerCmd.AddCommand(deleteVolumeCmd)
 
-	deleteVolumeCmd.Flags().BoolVar(
+	flagWithRequiresCreds(
+		deleteVolumeCmd.Flags(),
 		&root.withRequiresCreds,
-		"with-requires-credentials",
-		false,
-		withRequiresCredsDesc)
+		"")
 
-	deleteVolumeCmd.Flags().BoolVar(
+	flagWithSuccessNotFound(
+		deleteVolumeCmd.Flags(),
 		&root.withSuccessDeleteVolumeNotFound,
-		"with-success-not-found",
-		false,
-		`Treats a NotFound error code as a successful response.
-        Enabling this option also enables --with-spec-validation.`)
+		"")
 }

--- a/csc/cmd/controller_get_capacity.go
+++ b/csc/cmd/controller_get_capacity.go
@@ -39,10 +39,5 @@ var getCapacityCmd = &cobra.Command{
 
 func init() {
 	controllerCmd.AddCommand(getCapacityCmd)
-
-	getCapacityCmd.Flags().Var(
-		&getCapacity.caps,
-		"cap",
-		"one or more volume capabilities. "+
-			"ex: --cap 1,block --cap 5,mount,xfs,uid=500")
+	flagVolumeCapabilities(getCapacityCmd.Flags(), &getCapacity.caps)
 }

--- a/csc/cmd/controller_list_volumes.go
+++ b/csc/cmd/controller_list_volumes.go
@@ -67,29 +67,28 @@ func init() {
 		&listVolumes.maxEntries,
 		"max-entries",
 		0,
-		"the maximum number of entries to return")
+		"The maximum number of entries to return")
 
 	listVolumesCmd.Flags().StringVar(
 		&listVolumes.startingToken,
 		"starting-token",
 		"",
-		"the starting token used to retrieve paged data")
+		"The starting token used to retrieve paged data")
 
 	listVolumesCmd.Flags().BoolVar(
 		&listVolumes.paging,
 		"paging",
 		false,
-		"a flag that enables auto-paging")
+		"Enables auto-paging")
 
 	listVolumesCmd.Flags().StringVar(
 		&root.format,
 		"format",
 		"",
-		"the go template format used to emit the results")
+		"The Go template format used to emit the results")
 
-	listVolumesCmd.Flags().BoolVar(
+	flagWithRequiresAttribs(
+		listVolumesCmd.Flags(),
 		&root.withRequiresVolumeAttributes,
-		"with-requires-attributes",
-		false,
-		withRequiresRepAttribsDesc)
+		"")
 }

--- a/csc/cmd/controller_publish_volume.go
+++ b/csc/cmd/controller_publish_volume.go
@@ -72,22 +72,6 @@ func init() {
 		"",
 		"The ID of the node to which to publish the volume")
 
-	controllerPublishVolumeCmd.Flags().Var(
-		&controllerPublishVolume.caps,
-		"cap",
-		volumeCapabilityDesc)
-
-	controllerPublishVolumeCmd.Flags().Var(
-		&controllerPublishVolume.attribs,
-		"attrib",
-		attribsDesc)
-
-	controllerPublishVolumeCmd.Flags().BoolVar(
-		&root.withRequiresCreds,
-		"with-requires-credentials",
-		false,
-		withRequiresCredsDesc)
-
 	controllerPublishVolumeCmd.Flags().BoolVar(
 		&root.withRequiresNodeID,
 		"with-requires-node-id",
@@ -102,9 +86,19 @@ func init() {
 		`Marks the response's PublishVolumeInfo field as required.
         Enabling this option also enables --with-spec-validation.`)
 
-	controllerPublishVolumeCmd.Flags().BoolVar(
+	flagVolumeAttributes(
+		controllerPublishVolumeCmd.Flags(), &controllerPublishVolume.attribs)
+
+	flagVolumeCapability(
+		controllerPublishVolumeCmd.Flags(), &controllerPublishVolume.caps)
+
+	flagWithRequiresCreds(
+		controllerPublishVolumeCmd.Flags(),
+		&root.withRequiresCreds,
+		"")
+
+	flagWithRequiresAttribs(
+		controllerPublishVolumeCmd.Flags(),
 		&root.withRequiresVolumeAttributes,
-		"with-requires-attributes",
-		false,
-		withRequiresReqAttribsDesc)
+		"")
 }

--- a/csc/cmd/controller_unpublish_volume.go
+++ b/csc/cmd/controller_unpublish_volume.go
@@ -63,9 +63,8 @@ func init() {
 		"",
 		"The ID of the node from which to unpublish the volume")
 
-	controllerUnpublishVolumeCmd.Flags().BoolVar(
+	flagWithRequiresCreds(
+		controllerUnpublishVolumeCmd.Flags(),
 		&root.withRequiresCreds,
-		"with-requires-credentials",
-		false,
-		withRequiresCredsDesc)
+		"")
 }

--- a/csc/cmd/controller_validate_volume_capabilities.go
+++ b/csc/cmd/controller_validate_volume_capabilities.go
@@ -59,19 +59,12 @@ USAGE
 func init() {
 	controllerCmd.AddCommand(valVolCapsCmd)
 
-	valVolCapsCmd.Flags().Var(
-		&valVolCaps.caps,
-		"cap",
-		volumeCapabilityDesc)
+	flagVolumeAttributes(valVolCapsCmd.Flags(), &valVolCaps.attribs)
 
-	valVolCapsCmd.Flags().Var(
-		&valVolCaps.attribs,
-		"attrib",
-		attribsDesc)
+	flagVolumeCapabilities(valVolCapsCmd.Flags(), &valVolCaps.caps)
 
-	valVolCapsCmd.Flags().BoolVar(
+	flagWithRequiresAttribs(
+		valVolCapsCmd.Flags(),
 		&root.withRequiresVolumeAttributes,
-		"with-requires-attributes",
-		false,
-		withRequiresReqAttribsDesc)
+		"")
 }

--- a/csc/cmd/flags.go
+++ b/csc/cmd/flags.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"strconv"
+	"time"
+
+	flag "github.com/spf13/pflag"
+)
+
+// flagEndpoint adds the -e,--endpoint flag to the specified flagset.
+func flagEndpoint(fs *flag.FlagSet, addr *string, def string) {
+	fs.StringVarP(
+		addr,
+		"endpoint",
+		"e",
+		def,
+		`The CSI endpoint may also be specified by the environment variable
+        CSI_ENDPOINT. The endpoint should adhere to Go's network address
+        pattern:
+
+            * tcp://host:port
+            * unix:///path/to/file.sock.
+
+        If the network type is omitted then the value is assumed to be an
+        absolute or relative filesystem path to a UNIX socket file`)
+}
+
+// flagLogLevel adds the -l,--log-level flag to the specified flagset.
+func flagLogLevel(fs *flag.FlagSet, addr *logLevelArg, def string) {
+	if def != "" {
+		addr.Set(def)
+	}
+	fs.VarP(
+		addr,
+		"log-level",
+		"l",
+		`Sets the log level`)
+}
+
+// flagTimeout adds the -t,--timeout flag to the specified flagset.
+func flagTimeout(fs *flag.FlagSet, addr *time.Duration, def string) {
+	t, _ := time.ParseDuration(def)
+	fs.DurationVarP(
+		addr,
+		"timeout",
+		"t",
+		t,
+		`A duration string that specifies the timeout used for gRPC operations.
+        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", and
+        "h"`)
+}
+
+// flagWithRequestLogging adds the --with-request-logging flag to the
+// specified flagset.
+func flagWithRequestLogging(fs *flag.FlagSet, addr *bool, def string) {
+	fs.BoolVar(
+		addr,
+		"with-request-logging",
+		defBool(def),
+		`Enables gRPC request logging. Please note that gRPC requests are
+        logged at the INFO log level; so please adjust the log level accordingly.`)
+}
+
+// flagWithResponseLogging adds the --with-response-logging flag to the
+// specified flagset.
+func flagWithResponseLogging(fs *flag.FlagSet, addr *bool, def string) {
+	fs.BoolVar(
+		addr,
+		"with-response-logging",
+		defBool(def),
+		`Enables gRPC response logging. Please note that gRPC responses are
+        logged at the INFO log level; so please adjust the log level accordingly.`)
+}
+
+// flagWithSpecValidation adds the --with-spec-validation flag to the
+// specified flagset.
+func flagWithSpecValidation(fs *flag.FlagSet, addr *bool, def string) {
+	fs.BoolVar(
+		addr,
+		"with-spec-validation",
+		defBool(def),
+		`Enables validation of outgoing and incoming gRPC requests and responses
+        against the CSI specification.`)
+}
+
+// flagWithRequiresCreds adds the flag --with-requires-creds
+// to the provided flagset.
+func flagWithRequiresCreds(fs *flag.FlagSet, addr *bool, def string) {
+	fs.BoolVar(
+		addr,
+		"with-requires-creds",
+		defBool(def),
+		`Marks a request's UserCredentials field as required.
+        Enabling this option also enables --with-spec-validation.`)
+}
+
+// flagWithRequiresAttribs adds the flag --with-requires-attribs
+// to the provided flagset.
+func flagWithRequiresAttribs(fs *flag.FlagSet, addr *bool, def string) {
+	fs.BoolVar(
+		addr,
+		"with-requires-attribs",
+		defBool(def),
+		`Marks a request's and repsonse's VolumeAttributes field as required.
+        Enabling this option also enables --with-spec-validation.`)
+}
+
+// flagWithSuccessAlreadyExists adds the flag --with-success-already-exists
+// to the provided flagset.
+func flagWithSuccessAlreadyExists(fs *flag.FlagSet, addr *bool, def string) {
+	fs.BoolVar(
+		addr,
+		"with-success-create-already-exists",
+		defBool(def),
+		`Treats a CreateVolume response with an AlreadyExists error
+        code as a successful result. Enabling this option also enables
+        --with-spec-validation.`)
+}
+
+// flagWithSuccessNotFound adds the flag --with-success-not-found
+// to the provided flagset.
+func flagWithSuccessNotFound(fs *flag.FlagSet, addr *bool, def string) {
+	fs.BoolVar(
+		addr,
+		"with-success-delete-not-found",
+		defBool(def),
+		`Treats a DeleteVolume response with a NotFound error code
+        as a successful result. Enabling this option also enables
+        --with-spec-validation.`)
+}
+
+func defBool(def string) bool {
+	if def == "" {
+		return false
+	}
+	b, _ := strconv.ParseBool(def)
+	return b
+}
+
+// flagVolumeCapability adds the --cap flag to the specified flagset.
+func flagVolumeCapability(fs *flag.FlagSet, addr *volumeCapabilitySliceArg) {
+	fs.Var(
+		addr,
+		"cap",
+		`The volume capability is specified using the following format:
+`+flagVolumeCapabilityDescSuffix)
+}
+
+// flagVolumeAttributes adds the --attrib flag to the specified flagset.
+func flagVolumeAttributes(fs *flag.FlagSet, addr *mapOfStringArg) {
+	fs.Var(
+		addr,
+		"attrib",
+		`One or more key/value pairs may be specified to send with
+        the request as its VolumeAttributes field:
+
+            --attrib key1=val1,key2=val2 --attrib=key3=val3`)
+}
+
+// flagVolumeCapabilities adds the --cap flag to the specified flagset.
+func flagVolumeCapabilities(fs *flag.FlagSet, addr *volumeCapabilitySliceArg) {
+	fs.Var(
+		addr,
+		"cap",
+		`One or more volume capabilities may be specified using the following
+        format:
+`+flagVolumeCapabilityDescSuffix)
+}
+
+const flagVolumeCapabilityDescSuffix = `
+            ACCESS_MODE,ACCESS_TYPE[,FS_TYPE,MOUNT_FLAGS]
+
+        The ACCESS_MODE and ACCESS_TYPE values are required. Their values
+        may be the their string name or their gRPC integer value. For example,
+        the following two options are equivalent:
+
+            --cap 5,1
+            --cap MULTI_NODE_MULTI_WRITER,block
+
+        If the access type specified is "mount" (or its gRPC field value of 2)
+        then it's possible to specify a filesystem type and mount flags for
+        the volume capability. Multiple mount flags may be specified using
+        commas. For example:
+
+            --cap MULTI_NODE_MULTI_WRITER,mount,xfs,uid=500,gid=500`

--- a/csc/cmd/node_publish_volume.go
+++ b/csc/cmd/node_publish_volume.go
@@ -81,27 +81,11 @@ func init() {
 
                 --pub-info key1=val1,key2=val2 --pub-infoparams=key3=val3`)
 
-	nodePublishVolumeCmd.Flags().Var(
-		&nodePublishVolume.attribs,
-		"attrib",
-		attribsDesc)
-
-	nodePublishVolumeCmd.Flags().Var(
-		&nodePublishVolume.caps,
-		"cap",
-		volumeCapabilityDesc)
-
 	nodePublishVolumeCmd.Flags().BoolVar(
 		&nodePublishVolume.readOnly,
 		"read-only",
 		false,
 		"Mark the volume as read-only")
-
-	nodePublishVolumeCmd.Flags().BoolVar(
-		&root.withRequiresCreds,
-		"with-requires-credentials",
-		false,
-		withRequiresCredsDesc)
 
 	nodePublishVolumeCmd.Flags().BoolVar(
 		&root.withRequiresPubVolInfo,
@@ -110,9 +94,15 @@ func init() {
 		`Marks the request's PublishVolumeInfo field as required.
         Enabling this option also enables --with-spec-validation.`)
 
-	nodePublishVolumeCmd.Flags().BoolVar(
-		&root.withRequiresVolumeAttributes,
-		"with-requires-attributes",
-		false,
-		withRequiresReqAttribsDesc)
+	flagVolumeAttributes(
+		nodePublishVolumeCmd.Flags(), &nodePublishVolume.attribs)
+
+	flagVolumeCapability(
+		nodePublishVolumeCmd.Flags(), &nodePublishVolume.caps)
+
+	flagWithRequiresCreds(
+		nodePublishVolumeCmd.Flags(), &root.withRequiresCreds, "")
+
+	flagWithRequiresAttribs(
+		nodePublishVolumeCmd.Flags(), &root.withRequiresVolumeAttributes, "")
 }

--- a/csc/cmd/node_unpublish_volume.go
+++ b/csc/cmd/node_unpublish_volume.go
@@ -62,9 +62,6 @@ func init() {
 		"",
 		"The path from which to unmount the volume")
 
-	nodeUnpublishVolumeCmd.Flags().BoolVar(
-		&root.withRequiresCreds,
-		"with-requires-credentials",
-		false,
-		withRequiresCredsDesc)
+	flagWithRequiresCreds(
+		nodeUnpublishVolumeCmd.Flags(), &root.withRequiresCreds, "")
 }

--- a/csc/cmd/usage.go
+++ b/csc/cmd/usage.go
@@ -9,49 +9,6 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-const usageFormat = `NAME
-    {{.Use}} -- {{.Short}}
-
-SYNOPSIS
-    {{.CommandPath}} [flags] {{argName .}}{{if .HasAvailableSubCommands}}
-
-AVAILABLE COMMANDS{{range .Commands}}{{if (and .IsAvailableCommand (ne .Name "help"))}}{{printf "\n    %s" .Name}}{{end}}{{end}}{{end}}
-
-Use "{{.CommandPath}} -h,--help" for more information
-`
-
-const helpFormat = `NAME
-    {{.Use}} -- {{.Short}}
-
-SYNOPSIS
-    {{.CommandPath}} [flags] {{argName .}}{{if gt (len .Aliases) 0}}
-
-ALIASES
-    {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
-
-AVAILABLE COMMANDS{{range .Commands}}{{if (and .IsAvailableCommand (ne .Name "help"))}}{{printf "\n    %s" .Name}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-OPTIONS{{range localFlags}}{{printf "\n    %s\n        %s %s\n" (flagName .) .Usage (defaultValue .)}}{{end}}{{end}}{{if .HasAvailableInheritedFlags}}
-GLOBAL OPTIONS{{range inheritedFlags}}{{printf "\n    %s\n        %s %s\n" (flagName .) .Usage (defaultValue .)}}{{end}}{{end}}
-ENVIRONMENT OPTIONS
-    CSC_DEBUG
-        Setting CSC_DEBUG=true is the same as:
-
-            --log-level=debug --with-request-logging --with-response-logging
-
-    X_CSI_USER_CREDENTIALS
-        This environment variable may be used by RPCs to send user credentials.
-
-        csc does not allow user credentials via command line arguments in order
-        to prevent sensitive information from appearing as part of a process
-        listing.
-
-        One or more credential pairs may be specified, and either the user name
-        or passphrase may be quoted to preserve leading or trailing whitespace:
-
-            user1=pass user2="trailing whitespace " "user 3"=' pass'
-`
-
 func funcMap(cmd *cobra.Command) template.FuncMap {
 	return template.FuncMap{
 		"localFlags": func() chan *flag.Flag {
@@ -130,9 +87,9 @@ func defaultValue(f *flag.Flag) string {
 	}
 	switch f.Value.Type() {
 	case "string":
-		return fmt.Sprintf("(default value %q)", f.DefValue)
+		return fmt.Sprintf("\n\n        (default value %q)", f.DefValue)
 	default:
-		return fmt.Sprintf("(default value %v)", f.DefValue)
+		return fmt.Sprintf("\n\n        (default value %v)", f.DefValue)
 	}
 }
 
@@ -144,6 +101,10 @@ func flagName(f *flag.Flag) string {
 }
 
 func setHelpAndUsage(cmd *cobra.Command) {
+	cmd.SilenceErrors = true
+	if cmd.Runnable() {
+		cmd.SilenceUsage = true
+	}
 	cmd.SetHelpFunc(helpFunc)
 	cmd.SetUsageFunc(usageFunc)
 	for _, cmd := range cmd.Commands() {
@@ -151,35 +112,44 @@ func setHelpAndUsage(cmd *cobra.Command) {
 	}
 }
 
-const volumeCapabilityDesc = `One or more volume capabilities may be specified using
-        the following format:
+const usageFormat = `NAME
+    {{.Use}} -- {{.Short}}
 
-            ACCESS_MODE,ACCESS_TYPE[,FS_TYPE,MOUNT_FLAGS]
+SYNOPSIS
+    {{.CommandPath}} [flags] {{argName .}}{{if .HasAvailableSubCommands}}
 
-        The ACCESS_MODE and ACCESS_TYPE values are required. Their values
-        may be the their string name or their gRPC integer value. For example,
-        the following two options are equivalent:
+AVAILABLE COMMANDS{{range .Commands}}{{if (and .IsAvailableCommand (ne .Name "help"))}}{{printf "\n    %s" .Name}}{{end}}{{end}}{{end}}
 
-            --cap 5,1
-            --cap MULTI_NODE_MULTI_WRITER,block
+Use "{{.CommandPath}} -h,--help" for more information
+`
 
-        If the access type specified is "mount" (or its gRPC field value of 2)
-        then it's possible to specify a filesystem type and mount flags for
-        the volume capability. Multiple mount flags may be specified using
-        commas. For example:
+const helpFormat = `NAME
+    {{.Use}} -- {{.Short}}
 
-            --cap MULTI_NODE_MULTI_WRITER,mount,xfs,uid=500,gid=500`
+SYNOPSIS
+    {{.CommandPath}} [flags] {{argName .}}{{if gt (len .Aliases) 0}}
 
-const attribsDesc = `One or more key/value pairs may be specified to send with
-        the request as its VolumeAttributes field:
+ALIASES
+    {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}
 
-            --attrib key1=val1,key2=val2 --attrib=key3=val3`
+AVAILABLE COMMANDS{{range .Commands}}{{if (and .IsAvailableCommand (ne .Name "help"))}}{{printf "\n    %s" .Name}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
-const withRequiresCredsDesc = `Marks the request's UserCredentials field as required.
-        Enabling this option also enables --with-spec-validation.`
+OPTIONS{{range localFlags}}{{printf "\n    %s\n        %s %s\n" (flagName .) .Usage (defaultValue .)}}{{end}}{{end}}{{if .HasAvailableInheritedFlags}}
+GLOBAL OPTIONS{{range inheritedFlags}}{{printf "\n    %s\n        %s %s\n" (flagName .) .Usage (defaultValue .)}}{{end}}{{end}}
+ENVIRONMENT OPTIONS
+    X_CSI_DEBUG
+        Setting X_CSI_DEBUG=true is the same as:
+            --log-level=debug --with-request-logging --with-response-logging
 
-const withRequiresReqAttribsDesc = `Marks the request's VolumeAttributes field as required.
-        Enabling this option also enables --with-spec-validation.`
+    X_CSI_USER_CREDENTIALS
+        This environment variable may be used by RPCs to send user credentials.
 
-const withRequiresRepAttribsDesc = `Marks the response's VolumeInfo.Attributes field as required.
-        Enabling this option also enables --with-spec-validation.`
+        csc does not allow user credentials via command line arguments in order
+        to prevent sensitive information from appearing as part of a process
+        listing.
+
+        One or more credential pairs may be specified, and either the user name
+        or passphrase may be quoted to preserve leading or trailing whitespace:
+
+            user1=pass user2="trailing whitespace " "user 3"=' pass'
+`

--- a/csc/cmd/vartypes.go
+++ b/csc/cmd/vartypes.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/spf13/pflag"
 	"github.com/thecodeteam/gocsi"
 	"github.com/thecodeteam/gocsi/csi"
 )
@@ -171,26 +172,36 @@ func (s *docTypeArg) Set(val string) error {
 	return fmt.Errorf("invalid doc type: %s", val)
 }
 
-// logLevelArg is used for parsing the log level
 type logLevelArg struct {
+	pflag.Value
 	val log.Level
 	set bool
 }
 
-func (s *logLevelArg) String() string {
-	return "warn"
+func (a *logLevelArg) Val() (log.Level, bool) {
+	if a.set {
+		return a.val, false
+	}
+	return log.WarnLevel, true
 }
 
-func (s *logLevelArg) Type() string {
-	return "panic|fatal|error|warn|info|debug"
+func (a *logLevelArg) String() string {
+	if a.set {
+		return a.val.String()
+	}
+	return "WARN"
 }
 
-func (s *logLevelArg) Set(val string) error {
+func (a *logLevelArg) Type() string {
+	return "PANIC|FATAL|ERROR|WARN|INFO|DEBUG"
+}
+
+func (a *logLevelArg) Set(val string) error {
 	lvl, err := log.ParseLevel(val)
 	if err != nil {
 		return err
 	}
-	s.val = lvl
-	s.set = true
+	a.val = lvl
+	a.set = true
 	return nil
 }


### PR DESCRIPTION
This patch cleans up some of the CSC flags as well as no longer prints out the full help text when a command is in error.