### PR TITLE
Fix for Panic on Nil gRPC Response

### DIFF
--- a/controller_test.go
+++ b/controller_test.go
@@ -313,6 +313,14 @@ var _ = Describe("Controller", func() {
 				Ω(err).Should(Σ(gocsi.ErrVolumeIDRequired))
 			})
 		})
+		Context("Not Found", func() {
+			BeforeEach(func() {
+				volID = "5"
+			})
+			It("Should Be Valid", func() {
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+		})
 		Context("Missing Version", func() {
 			BeforeEach(func() {
 				version = nil

--- a/interceptors_idempotency.go
+++ b/interceptors_idempotency.go
@@ -457,6 +457,7 @@ func (i *idempotencyInterceptor) deleteVolume(
 			return nil, err
 		}
 		if volInfo == nil {
+			log.WithField("volumeID", req.VolumeId).Info("idempotent delete.a")
 			return nil, status.Error(codes.NotFound, req.VolumeId)
 		}
 		volExists = true
@@ -474,8 +475,8 @@ func (i *idempotencyInterceptor) deleteVolume(
 
 	// Indicate an idempotent delete operation if the volume does not exist.
 	if !volExists {
-		log.WithField("volumeID", req.VolumeId).Info("idempotent delete")
-		return &csi.DeleteVolumeResponse{}, nil
+		log.WithField("volumeID", req.VolumeId).Info("idempotent delete.b")
+		return nil, status.Error(codes.NotFound, req.VolumeId)
 	}
 
 	return handler(ctx, req)

--- a/interceptors_logger.go
+++ b/interceptors_logger.go
@@ -111,12 +111,14 @@ func (s *loggingInterceptor) handle(
 	reqID, reqIDOK := GetRequestID(ctx)
 
 	// Print the request
-	fmt.Fprintf(w, "%s: ", method)
-	if reqIDOK {
-		fmt.Fprintf(w, "REQ %04d", reqID)
+	if s.opts.reqw != nil {
+		fmt.Fprintf(w, "%s: ", method)
+		if reqIDOK {
+			fmt.Fprintf(w, "REQ %04d", reqID)
+		}
+		rprintReqOrRep(w, req)
+		fmt.Fprintln(s.opts.reqw, w.String())
 	}
-	rprintReqOrRep(w, req)
-	fmt.Fprintln(s.opts.reqw, w.String())
 
 	w.Reset()
 

--- a/mock/service/controller.go
+++ b/mock/service/controller.go
@@ -57,7 +57,7 @@ func (s *service) DeleteVolume(
 		s.vols = s.vols[:len(s.vols)-1]
 	}()
 
-	return &csi.DeleteVolumeResponse{}, nil
+	return nil, status.Error(codes.NotFound, req.VolumeId)
 }
 
 func (s *service) ControllerPublishVolume(


### PR DESCRIPTION
This patch fixes a critical runtime error that occurred when a CSI SP returned a nil gRPC response value. Due to the way gRPC handles return values in combination with Go's [`interface{}`/`nil` comparison rules](https://golang.org/doc/faq#nil_error), it is not possible to determine if the response is nil using `obj == nil`. This patch provides a means of nil response detection that does not rely on reflection, but instead uses a pre-populated map of all of the CSI RPCs response types and their associated nil values.

The issue lies in the gRPC-generated code:

```go
func (c *controllerClient) DeleteVolume(ctx context.Context, in *DeleteVolumeRequest, opts ...grpc.CallOption) (*DeleteVolumeResponse, error) {
    out := new(DeleteVolumeResponse)
    err := grpc.Invoke(ctx, "/csi.Controller/DeleteVolume", in, out, c.cc, opts...)
    if err != nil {
        return nil, err
    }
    return out, nil
}
```

Because [`grpc.Invoke`](https://godoc.org/google.golang.org/grpc#Invoke)'s `reply` parameter is of type `interface{}`, it does not matter if `out` is set to `nil` in the invoked delegate. The variable `out` is never nil according to Go's rules about comparing `nil` and an `interface{}`. The value of `reply` is already an `interface{}` with an internal type of `*DeleteVolumeResponse`, and that is not changing.

Replaces #38.

cc @codenrhoden 