### PR TITLE
Minor updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,16 @@ $(GINKGO):
 ifneq (true,$(TRAVIS))
 test:  build
 endif
+
+# Because Travis-CI's containers have limited resources, the Mock SP's
+# idempotency provider's timeout needs to be increased from the default
+# value of 0 to 1s. This ensures that lack of system resources will not
+# prevent a single, non-concurrent RPC from failing due to an OpPending
+# error.
+ifeq (true,$(TRAVIS))
+export X_CSI_MOCK_IDEMPOTENCY_TIMEOUT=1s
+endif
+
 test: | $(GINKGO)
 	$(GINKGO) $(GINKGO_RUN_OPTS) . || test "$$?" -eq "197"
 

--- a/interceptors.go
+++ b/interceptors.go
@@ -7,25 +7,6 @@ import (
 	"github.com/thecodeteam/gocsi/csi"
 )
 
-var nilResponses = map[string]interface{}{
-	CreateVolume:               (*csi.CreateVolumeResponse)(nil),
-	DeleteVolume:               (*csi.DeleteVolumeResponse)(nil),
-	ControllerPublishVolume:    (*csi.ControllerPublishVolumeResponse)(nil),
-	ControllerUnpublishVolume:  (*csi.ControllerUnpublishVolumeResponse)(nil),
-	ValidateVolumeCapabilities: (*csi.ValidateVolumeCapabilitiesResponse)(nil),
-	ListVolumes:                (*csi.ListVolumesResponse)(nil),
-	GetCapacity:                (*csi.GetCapacityResponse)(nil),
-	ControllerGetCapabilities:  (*csi.ControllerGetCapabilitiesResponse)(nil),
-	ControllerProbe:            (*csi.ControllerProbeResponse)(nil),
-	GetSupportedVersions:       (*csi.GetSupportedVersionsResponse)(nil),
-	GetPluginInfo:              (*csi.GetPluginInfoResponse)(nil),
-	GetNodeID:                  (*csi.GetNodeIDResponse)(nil),
-	NodePublishVolume:          (*csi.NodePublishVolumeResponse)(nil),
-	NodeUnpublishVolume:        (*csi.NodeUnpublishVolumeResponse)(nil),
-	NodeProbe:                  (*csi.NodeProbeResponse)(nil),
-	NodeGetCapabilities:        (*csi.NodeGetCapabilitiesResponse)(nil),
-}
-
 // ChainUnaryClient chains one or more unary, client interceptors
 // together into a left-to-right series that can be provided to a
 // new gRPC client.
@@ -124,6 +105,25 @@ func ChainUnaryServer(
 		}
 		return c(ctx, req)
 	}
+}
+
+var nilResponses = map[string]interface{}{
+	CreateVolume:               (*csi.CreateVolumeResponse)(nil),
+	DeleteVolume:               (*csi.DeleteVolumeResponse)(nil),
+	ControllerPublishVolume:    (*csi.ControllerPublishVolumeResponse)(nil),
+	ControllerUnpublishVolume:  (*csi.ControllerUnpublishVolumeResponse)(nil),
+	ValidateVolumeCapabilities: (*csi.ValidateVolumeCapabilitiesResponse)(nil),
+	ListVolumes:                (*csi.ListVolumesResponse)(nil),
+	GetCapacity:                (*csi.GetCapacityResponse)(nil),
+	ControllerGetCapabilities:  (*csi.ControllerGetCapabilitiesResponse)(nil),
+	ControllerProbe:            (*csi.ControllerProbeResponse)(nil),
+	GetSupportedVersions:       (*csi.GetSupportedVersionsResponse)(nil),
+	GetPluginInfo:              (*csi.GetPluginInfoResponse)(nil),
+	GetNodeID:                  (*csi.GetNodeIDResponse)(nil),
+	NodePublishVolume:          (*csi.NodePublishVolumeResponse)(nil),
+	NodeUnpublishVolume:        (*csi.NodeUnpublishVolumeResponse)(nil),
+	NodeProbe:                  (*csi.NodeProbeResponse)(nil),
+	NodeGetCapabilities:        (*csi.NodeGetCapabilitiesResponse)(nil),
 }
 
 func isResponseNil(method string, rep interface{}) bool {

--- a/interceptors_spec_validator.go
+++ b/interceptors_spec_validator.go
@@ -240,11 +240,11 @@ func (s *specValidator) handle(
 	isNilRep := isResponseNil(method, rep)
 
 	// Handle possible non-zero successful exit codes.
-	if err2 := s.handleResponseError(method, err); err2 != nil {
+	if err := s.handleResponseError(method, err); err != nil {
 		if isNilRep {
-			return nil, err2
+			return nil, err
 		}
-		return nil, err2
+		return nil, err
 	}
 
 	// If the response is nil then go ahead and return a nil value


### PR DESCRIPTION
This PR includes two changes:

### Addendum to `isResposneNil`
This first patch includes minor adjustments to the previous commit that added the function and logic for `isResponseNil`.

### Travis-CI Testing & Limited Resources
Because Travis-CI's containers have limited resources, the Mock SP's idempotency provider's timeout needs to be increased from the default value of 0 to 1s. This ensures that lack of system resources will not prevent a single, non-concurrent RPC from failing due to an OpPending error.

FYI, @codenrhoden, I realized how Travis-CI resource exhaustion can lead to test failures due to `OpPending` errors for test cases with single, non-concurrent operations. First of all, **all** tests run on Travis-CI are run in parallel, meaning that even if we're not testing 1,000 concurrent `DeleteVolume` calls, a `DeleteVolume` test may be executed at the same time as another test that is validating 1,000 `CreateVolume` RPCs. Separate and discreet endpoints of course, but still, the system's resources are in play.

Now let's look at `trylock.go`:

```go
func (m *mutex) TryLock(timeout time.Duration) bool {
	timer := time.NewTimer(timeout)
	select {
	case m.c <- struct{}{}:
		timer.Stop()
		return true
	case <-time.After(timeout):
	}
	return false
}
```

I believe what is occurring is that the `select` statement is hitting the timeout case (defaults to `0s`) before the lock's channel is ready. This is the expected behavior when some other goroutine holds the lock, but in this case I believe it's happening simply because the timer's channel is ready before the lock's channel thanks to the system's resources and the Go runtime.

It's the best, educated guess as to why a test with a single `DeleteVolume` RPC would fail with `OpPending` when there are no other RPCs occurring to that test case's endpoint.