### PR TITLE
CSP BeforeServe

### DIFF
--- a/controller_test.go
+++ b/controller_test.go
@@ -2,7 +2,6 @@ package gocsi_test
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"path"
 	"sync"
@@ -10,8 +9,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/thecodeteam/gocsi"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/thecodeteam/gocsi"
 	"github.com/thecodeteam/gocsi/mock/service"
 )
 
@@ -205,15 +204,15 @@ var _ = Describe("Controller", func() {
 					float64(count), float64(bucketSize)); r > 0 {
 					buckets++
 				}
-				fmt.Fprintf(
-					GinkgoWriter, "count=%d, buckets=%d\n", count, buckets)
+				//fmt.Fprintf(
+				//	GinkgoWriter, "count=%d, buckets=%d\n", count, buckets)
 				for i := 0; i < buckets; i++ {
 					go func(i int) {
 						defer GinkgoRecover()
 						start := i * bucketSize
 						for j := start; j < start+bucketSize && j < count; j++ {
-							fmt.Fprintf(
-								GinkgoWriter, "bucket=%d, index=%d\n", i, j)
+							//fmt.Fprintf(
+							//	GinkgoWriter, "bucket=%d, index=%d\n", i, j)
 							go worker()
 						}
 					}(i)

--- a/csp/README.md
+++ b/csp/README.md
@@ -20,13 +20,25 @@ path `github.com/thecodeteam/csi-sp`:
 
 ```shell
 $ ./csp.sh github.com/thecodeteam/csi-sp
-creating $GOPATH/src/github.com/thecodeteam/csi-sp/main.go
-creating $GOPATH/src/github.com/thecodeteam/csi-sp/provider/provider.go
-creating $GOPATH/src/github.com/thecodeteam/csi-sp/service/service.go
-creating $GOPATH/src/github.com/thecodeteam/csi-sp/service/controller.go
-creating $GOPATH/src/github.com/thecodeteam/csi-sp/service/identity.go
-creating $GOPATH/src/github.com/thecodeteam/csi-sp/service/node.go
-building csi-sp
+creating project directories:
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/provider
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/service
+creating project files:
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/main.go
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/provider/provider.go
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/service/service.go
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/service/controller.go
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/service/idemp.go
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/service/identity.go
+  /home/akutz/go/src/github.com/thecodeteam/csi-sp/service/node.go
+use golang/dep? Enter yes (default) or no and press [ENTER]:
+  downloading golang/dep@v0.3.2
+  executing dep init
+building csi-sp:
+  success!
+  example: CSI_ENDPOINT=csi.sock \
+           /home/akutz/go/src/github.com/thecodeteam/csi-sp/csi-sp
 ```
 
 The new SP adheres to the following structure:
@@ -39,6 +51,7 @@ The new SP adheres to the following structure:
 |-- service
 |   |
 |   |-- controller.go
+|   |-- idemp.go
 |   |-- identity.go
 |   |-- node.go
 |   |-- service.go
@@ -54,8 +67,15 @@ modified to:
 * Add an idempotency provider
 * Supply default values for the SP's environment variable configuration properties
 
+The generated file configures the following options and their default values:
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `X_CSI_IDEMP` | `true` | In concert with the file `service/idemp.go`, this option enables idempotency for the SP |
+| `X_CSI_SUPPORTED_VERSIONS` | `0.0.0` | The CSI versions supported by the SP. Settings this option also relieves the SP of its responsibility to provide an implementation of the RPC `GetSupportedVersions` |
+
 Please see the Mock SP's [`provider.go`](../mock/provider/provider.go) file
-for an example of each.
+for a more complete example.
 
 ### Service
 The `service` package is where the business logic occurs. The files `controller.go`,
@@ -63,6 +83,11 @@ The `service` package is where the business logic occurs. The files `controller.
 developer creating a new CSI SP with `csp` will work mostly in these files. Each
 of the files have a complete skeleton implementation for their respective service's
 remote procedure calls (RPC).
+
+The file `idemp.go` contains a skeleton implementation of the interface
+[`gocsi.IdemptotencyProvider`](../interceptors_idempotency.go). An SP is able
+to achieve idempotency simply by implementing the functions contained in this
+file.
 
 ### Main
 The root, or `main`, package leverages `csp` to launch the SP as a stand-alone

--- a/csp/csp_interceptors.go
+++ b/csp/csp_interceptors.go
@@ -7,8 +7,8 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-	"github.com/thecodeteam/gocsi"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/thecodeteam/gocsi"
 )
 
 func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
@@ -185,12 +185,6 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 		sp.Interceptors = append(sp.Interceptors,
 			gocsi.NewIdempotentInterceptor(sp.IdempotencyProvider, opts...))
 		log.WithFields(fields).Debug("enabled idempotency provider")
-	}
-
-	// Add interceptors to the client if any are configured.
-	if len(sp.Interceptors) > 0 {
-		sp.ServerOpts = append(sp.ServerOpts,
-			grpc.UnaryInterceptor(gocsi.ChainUnaryServer(sp.Interceptors...)))
 	}
 
 	return

--- a/interceptors_idempotency.go
+++ b/interceptors_idempotency.go
@@ -1,16 +1,17 @@
 package gocsi
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"golang.org/x/net/context"
+	xctx "golang.org/x/net/context"
 )
 
 // IdempotencyProvider is the interface that works with a server-side,
@@ -145,7 +146,7 @@ func isOpPending(err error) bool {
 }
 
 func (i *idempotencyInterceptor) handle(
-	ctx context.Context,
+	ctx xctx.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler) (interface{}, error) {

--- a/mock/service/idemp.go
+++ b/mock/service/idemp.go
@@ -1,15 +1,14 @@
 package service
 
 import (
+	"context"
 	"path"
-
-	xctx "golang.org/x/net/context"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 func (s *service) GetVolumeID(
-	ctx xctx.Context,
+	ctx context.Context,
 	name string) (string, error) {
 
 	i, v := s.findVol("name", name)
@@ -20,7 +19,7 @@ func (s *service) GetVolumeID(
 }
 
 func (s *service) GetVolumeInfo(
-	ctx xctx.Context,
+	ctx context.Context,
 	id, name string) (*csi.VolumeInfo, error) {
 
 	var (
@@ -42,7 +41,7 @@ func (s *service) GetVolumeInfo(
 }
 
 func (s *service) IsControllerPublished(
-	ctx xctx.Context,
+	ctx context.Context,
 	id, nodeID string) (map[string]string, error) {
 
 	_, v := s.findVol("id", id)
@@ -53,7 +52,7 @@ func (s *service) IsControllerPublished(
 }
 
 func (s *service) IsNodePublished(
-	ctx xctx.Context,
+	ctx context.Context,
 	id string,
 	pubInfo map[string]string,
 	targetPath string) (bool, error) {


### PR DESCRIPTION
This patch adds a new function to `csp.StoragePlugin`:

```go
BeforeServe func(context.Context, *StoragePlugin, net.Listener) error
```

The `BeforeServe` function allows an SP to participate in the SP lifecycle and modify interceptors and/or server options before the gRPC server is started.