### PR TITLE
CSP GetPluginInfo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,13 @@ jobs:
         install: true
         script:  make -C $PROG
 
+      # Test GoCSI's csp.sh script by creating and serving new SP and
+      # then using csc to invoke GetSupportedVersions and GetPluginInfo
+      - stage:   test
+        env:     JOB=csi-sp
+        install: make -C csc
+        script:  make csi-sp
+
       # Test GoCSI using the Mock CSI plug-in.
       - stage:   test
         env:     JOB=test

--- a/csp/csp.sh
+++ b/csp/csp.sh
@@ -362,13 +362,24 @@ dep_init() {
     chmod 0755 "$DEP_BIN"
     mv -f "$DEP_BIN" "$DEP"
   fi
-  if [ -e Gopkg.toml ]; then
-    echo "  executing dep ensure"
-    if ! "$DEP" ensure > "$DEP_LOG" 2>&1; then cat "$DEP_LOG"; fi
-  else
-    echo "  executing dep init"
-    if ! "$DEP" init > "$DEP_LOG" 2>&1; then cat "$DEP_LOG"; fi
+  if [ ! -e Gopkg.toml ]; then
+    cat << EOF > Gopkg.toml
+# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
+# for detailed Gopkg.toml documentation.
+#
+# Refer to https://github.com/toml-lang/toml for detailed TOML docs.
+
+[[constraint]]
+  name = "github.com/container-storage-interface/spec"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/thecodeteam/gocsi"
+  branch = "master"
+EOF
   fi
+  echo "  executing dep ensure"
+  if ! "$DEP" ensure > "$DEP_LOG" 2>&1; then cat "$DEP_LOG"; fi
   rm -f "$DEP_LOG"
 }
 

--- a/csp/csp_usage.go
+++ b/csp/csp_usage.go
@@ -43,6 +43,22 @@ GLOBAL OPTIONS
         bypass the SP's GetSupportedVersions RPC and return the list of
         specified versions instead.
 
+    X_CSI_PLUGIN_INFO
+        The plug-in information is specified via the following
+        comma-separated format:
+
+            NAME,VENDOR_VERSION,MANIFEST
+
+        The MANIFEST value may be a series of key/value pairs where either
+        the key or value may be quoted to preserve leading or trailing
+        whitespace. For example:
+
+            key1=val1 key2="val2 " "key 3"=' val3'
+
+        Setting this environment variable will cause the program to
+        bypass the SP's GetPluginInfo RPC and returns the specified
+        information instead.
+
     X_CSI_REQ_LOGGING
         A flag that enables logging of incoming requests to STDOUT.
 


### PR DESCRIPTION
This patch adds the option to specify an SP's plug-in information via the environment variable `X_CSI_PLUGIN_INFO`.