### PR TITLE
Add CSP ability to only run node/controller svc

### DIFF
--- a/csp/csp_envvars.go
+++ b/csp/csp_envvars.go
@@ -68,6 +68,16 @@ const (
 	// information instead.
 	EnvVarPluginInfo = "X_CSI_PLUGIN_INFO"
 
+	// EnvVarNodeSvcOnly is the name of the environment variable
+	// used to specify that only the CSI Node Service should be started,
+	// meaning that the Controller service should not
+	EnvVarNodeSvcOnly = "X_CSI_NODESVC_ONLY"
+
+	// EnvVarCtrlSvcOnly is the name of the environment variable
+	// used to specify that only the CSI Controller Service should be
+	// started, meaning that the Node service should not
+	EnvVarCtrlSvcOnly = "X_CSI_CTRLSVC_ONLY"
+
 	// EnvVarReqLogging is the name of the environment variable
 	// used to determine whether or not to enable request logging.
 	//


### PR DESCRIPTION
Plugins that can can be centralized will only want to run the Controller
or Node Service depending on the node. Add Env vars that enable that,
while still defaulting to running all services.