### PR TITLE
csc: Use gRPC error code as exit code

### DIFF
--- a/csc/cmd/root.go
+++ b/csc/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
 
 	"github.com/thecodeteam/gocsi"
 )
@@ -144,11 +145,15 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintf(
-			os.Stderr,
-			"%v\n\nPlease use -h,--help for more information\n",
-			err)
-		os.Exit(1)
+		exitCode := 1
+		if stat, ok := status.FromError(err); ok {
+			exitCode = int(stat.Code())
+			fmt.Fprintln(os.Stderr, stat.Message())
+		} else {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		}
+		fmt.Fprintf(os.Stderr, "\nPlease use -h,--help for more information\n")
+		os.Exit(exitCode)
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -8,12 +8,9 @@ import (
 )
 
 // ErrVolumeNotFound returns an error indicating a volume with the
-// specified ID cannot be found. This function must be used by SPs
-// for the idempotent interceptor to be accurate. That or SPs should,
-// for a NotFound error relating to a volume, prefix the associated
-// message with "volumeID=".
+// specified ID cannot be found.
 func ErrVolumeNotFound(id string) error {
-	return status.Errorf(codes.NotFound, "volumeID=%s", id)
+	return status.Errorf(codes.NotFound, "volume not found: %s", id)
 }
 
 // ErrMissingCSIEndpoint occurs when the value for the environment


### PR DESCRIPTION
This patch updates csc to use the gRPC exit code (if there is one) as the csc process's exit code. For example:

```shell
$ csc/csc -e csi.sock c ls
invalid request version: 0.0.0

Please use -h,--help for more information

$ echo $?
3
```

```shell
$ csc/csc -e csi.sock -v 0.1.0 c attach 4 --node-id 4 --cap 5,block
volume not found: 4

Please use -h,--help for more information

$ echo $?
5
```