### PR TITLE
Remove Dropping of Errs for Create/Delete

### DIFF
--- a/csc/cmd/controller_create_volume.go
+++ b/csc/cmd/controller_create_volume.go
@@ -100,11 +100,6 @@ func init() {
 
 	flagVolumeCapabilities(createVolumeCmd.Flags(), &createVolume.caps)
 
-	flagWithSuccessAlreadyExists(
-		createVolumeCmd.Flags(),
-		&root.withSuccessCreateVolumeAlreadyExists,
-		"")
-
 	flagWithRequiresCreds(
 		createVolumeCmd.Flags(),
 		&root.withRequiresCreds,

--- a/csc/cmd/controller_delete_volume.go
+++ b/csc/cmd/controller_delete_volume.go
@@ -53,9 +53,4 @@ func init() {
 		deleteVolumeCmd.Flags(),
 		&root.withRequiresCreds,
 		"")
-
-	flagWithSuccessNotFound(
-		deleteVolumeCmd.Flags(),
-		&root.withSuccessDeleteVolumeNotFound,
-		"")
 }

--- a/csc/cmd/interceptors.go
+++ b/csc/cmd/interceptors.go
@@ -42,8 +42,6 @@ func getClientInterceptorsDialOpt() grpc.DialOption {
 	// Configure the spec validator.
 	root.withSpecValidator = root.withSpecValidator ||
 		root.withRequiresCreds ||
-		root.withSuccessCreateVolumeAlreadyExists ||
-		root.withSuccessDeleteVolumeNotFound ||
 		root.withRequiresNodeID ||
 		root.withRequiresPubVolInfo ||
 		root.withRequiresVolumeAttributes
@@ -73,16 +71,6 @@ func getClientInterceptorsDialOpt() grpc.DialOption {
 			specOpts = append(specOpts,
 				specvalidator.WithRequiresVolumeAttributes())
 			log.Debug("enabled spec validator opt: requires vol attribs")
-		}
-		if root.withSuccessCreateVolumeAlreadyExists {
-			specOpts = append(specOpts,
-				specvalidator.WithSuccessCreateVolumeAlreadyExists())
-			log.Debug("enabled spec validator opt: create exists success")
-		}
-		if root.withSuccessDeleteVolumeNotFound {
-			specOpts = append(specOpts,
-				specvalidator.WithSuccessDeleteVolumeNotFound())
-			log.Debug("enabled spec validator opt: delete !exists success")
 		}
 		iceptors = append(iceptors,
 			specvalidator.NewClientSpecValidator(specOpts...))

--- a/csc/cmd/root.go
+++ b/csc/cmd/root.go
@@ -38,13 +38,11 @@ var root struct {
 	withReqLogging bool
 	withRepLogging bool
 
-	withSpecValidator                    bool
-	withRequiresCreds                    bool
-	withSuccessCreateVolumeAlreadyExists bool
-	withSuccessDeleteVolumeNotFound      bool
-	withRequiresNodeID                   bool
-	withRequiresPubVolInfo               bool
-	withRequiresVolumeAttributes         bool
+	withSpecValidator            bool
+	withRequiresCreds            bool
+	withRequiresNodeID           bool
+	withRequiresPubVolInfo       bool
+	withRequiresVolumeAttributes bool
 }
 
 var (

--- a/middleware.go
+++ b/middleware.go
@@ -32,8 +32,6 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 		withRepLogging         = sp.getEnvBool(ctx, EnvVarRepLogging)
 		withSerialVol          = sp.getEnvBool(ctx, EnvVarSerialVolAccess)
 		withSpec               = sp.getEnvBool(ctx, EnvVarSpecValidation)
-		withNewVolExists       = sp.getEnvBool(ctx, envVarNewVolExists)
-		withDelVolNotFound     = sp.getEnvBool(ctx, envVarDelVolNotFound)
 		withNodeID             = sp.getEnvBool(ctx, EnvVarRequireNodeID)
 		withPubVolInfo         = sp.getEnvBool(ctx, EnvVarRequirePubVolInfo)
 		withVolAttribs         = sp.getEnvBool(ctx, EnvVarRequireVolAttribs)
@@ -59,8 +57,6 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 	// Enable spec validation if any of the spec-related options are enabled.
 	withSpec = withSpec ||
 		withCreds ||
-		withNewVolExists ||
-		withDelVolNotFound ||
 		withNodeID ||
 		withPubVolInfo ||
 		withVolAttribs
@@ -149,16 +145,6 @@ func (sp *StoragePlugin) initInterceptors(ctx context.Context) {
 			specOpts = append(specOpts,
 				specvalidator.WithRequiresVolumeAttributes())
 			log.Debug("enabled spec validator opt: requires vol attribs")
-		}
-		if withNewVolExists {
-			specOpts = append(specOpts,
-				specvalidator.WithSuccessCreateVolumeAlreadyExists())
-			log.Debug("enabled spec validator opt: create exists success")
-		}
-		if withDelVolNotFound {
-			specOpts = append(specOpts,
-				specvalidator.WithSuccessDeleteVolumeNotFound())
-			log.Debug("enabled spec validator opt: delete !exists success")
 		}
 		sp.Interceptors = append(sp.Interceptors,
 			specvalidator.NewServerSpecValidator(specOpts...))

--- a/usage.go
+++ b/usage.go
@@ -106,18 +106,6 @@ GLOBAL OPTIONS
         A flag that enables validation of incoming requests and outgoing
         responses against the CSI specification.
 
-    X_CSI_CREATE_VOL_ALREADY_EXISTS
-        A flag that enables treating CreateVolume responses as successful
-        when they have an associated error code of AlreadyExists.
-
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
-
-    X_CSI_DELETE_VOL_NOT_FOUND
-        A flag that enables treating DeleteVolume responses as successful
-        when they have an associated error code of NotFound.
-
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
-
     X_CSI_REQUIRE_NODE_ID
         A flag that enables treating the following fields as required:
             * ControllerPublishVolumeRequest.NodeId


### PR DESCRIPTION
This patch removes the feature of the spec validator middleware that is able to drop errors for the `CreateVolume` and `DeleteVolume` RPCs when a volume already exists or is not found. This feature is no longer relevant with the latest spec.