### PR TITLE
Spec Validation for Response Msgs - Off & Detailed

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,22 @@ environment variables:
     </tr>
     <tr>
       <td><code>X_CSI_SPEC_VALIDATION</code></td>
-      <td>A flag that enables validation of incoming requests and outgoing
-      responses against the CSI specification.</td>
+      <td>Setting <code>X_CSI_SPEC_VALIDATION=true</code> is the same as:
+        <ul>
+          <li><code>X_CSI_SPEC_REQ_VALIDATION=true</code></li>
+          <li><code>X_CSI_SPEC_REP_VALIDATION=true</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>X_CSI_SPEC_REQ_VALIDATION</code></td>
+      <td>A flag that enables the validation of CSI request messages.</td>
+    </tr>
+    <tr>
+      <td><code>X_CSI_SPEC_REP_VALIDATION</code></td>
+      <td>A flag that enables the validation of CSI response messages.
+      Invalid responses are marshalled into a gRPC error with a code
+      of <code>Internal</code>.</td>
     </tr>
     <tr>
       <td><code>X_CSI_REQUIRE_NODE_ID</code></td>
@@ -229,7 +243,7 @@ environment variables:
           <li><code>ControllerPublishVolumeRequest.NodeId</code></li>
           <li><code>GetNodeIDResponse.NodeId</code></li>
       </ul>
-      <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+      <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -240,7 +254,7 @@ environment variables:
           <li><code>ControllerPublishVolumeResponse.PublishVolumeInfo</code></li>
           <li><code>NodePublishVolumeRequest.PublishVolumeInfo</code></li>
         </ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -252,7 +266,7 @@ environment variables:
           <li><code>ValidateVolumeCapabilitiesRequest.VolumeAttributes</code></li>
           <li><code>NodePublishVolumeRequest.VolumeAttributes</code></li>
         </ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -266,7 +280,7 @@ environment variables:
           <li><code>X_CSI_REQUIRE_CREDS_NODE_PUB_VOL=true</code></li>
           <li><code>X_CSI_REQUIRE_CREDS_NODE_UNPUB_VOL=true</code></li>
         </ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -274,7 +288,7 @@ environment variables:
       <td>
         <p>A flag that enables treating the following fields as required:</p>
         <ul><li><code>CreateVolumeRequest.UserCredentials</code></li></ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -282,7 +296,7 @@ environment variables:
       <td>
         <p>A flag that enables treating the following fields as required:</p>
         <ul><li><code>DeleteVolumeRequest.UserCredentials</code></li></ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -290,7 +304,7 @@ environment variables:
       <td>
         <p>A flag that enables treating the following fields as required:</p>
         <ul><li><code>ControllerPublishVolumeRequest.UserCredentials</code></li></ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -298,7 +312,7 @@ environment variables:
       <td>
         <p>A flag that enables treating the following fields as required:</p>
         <ul><li><code>ControllerUnpublishVolumeRequest.UserCredentials</code></li></ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -306,7 +320,7 @@ environment variables:
       <td>
         <p>A flag that enables treating the following fields as required:</p>
         <ul><li><code>NodePublishVolumeRequest.UserCredentials</code></li></ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>
@@ -314,7 +328,7 @@ environment variables:
       <td>
         <p>A flag that enables treating the following fields as required:</p>
         <ul><li><code>NodeUnpublishVolumeRequest.UserCredentials</code></li></ul>
-        <p>Enabling this option sets <code>X_CSI_SPEC_VALIDATION=true</code></p>
+        <p>Enabling this option sets <code>X_CSI_SPEC_REQ_VALIDATION=true</code></p>
       </td>
     </tr>
     <tr>

--- a/gocsi.sh
+++ b/gocsi.sh
@@ -82,6 +82,9 @@ func New() gocsi.StoragePluginProvider {
 		},
 
 		EnvVars: []string{
+			// Enable request validation.
+			gocsi.EnvVarSpecReqValidation + "=true",
+
 			// Enable serial volume access.
 			gocsi.EnvVarSerialVolAccess + "=true",
 

--- a/mock/provider/provider.go
+++ b/mock/provider/provider.go
@@ -36,6 +36,9 @@ func New() gocsi.StoragePluginProvider {
 			// Enable serial volume access.
 			gocsi.EnvVarSerialVolAccess + "=true",
 
+			// Enable request and response validation.
+			gocsi.EnvVarSpecValidation + "=true",
+
 			// Treat the following fields as required:
 			//    * ControllerPublishVolumeRequest.NodeId
 			//    * GetNodeIDResponse.NodeId

--- a/testing/gocsi_test.go
+++ b/testing/gocsi_test.go
@@ -119,8 +119,8 @@ func Σ(a error) gomegaTypes.GomegaMatcher {
 }
 
 // ΣCM is a custom Ginkgo matcher that compares two gRPC errors.
-func ΣCM(c codes.Code, m string) gomegaTypes.GomegaMatcher {
-	return &grpcErrorMatcher{exp: status.Error(c, m)}
+func ΣCM(c codes.Code, m string, args ...interface{}) gomegaTypes.GomegaMatcher {
+	return &grpcErrorMatcher{exp: status.Errorf(c, m, args...)}
 }
 
 const string128 = "0000000000000000000000000000000000000000000000000000000000" +

--- a/usage.go
+++ b/usage.go
@@ -103,22 +103,31 @@ GLOBAL OPTIONS
         generated using an atomic sequence counter.
 
     X_CSI_SPEC_VALIDATION
-        A flag that enables validation of incoming requests and outgoing
-        responses against the CSI specification.
+        Setting X_CSI_SPEC_VALIDATION=true is the same as:
+            X_CSI_SPEC_REQ_VALIDATION=true
+            X_CSI_SPEC_REP_VALIDATION=true
+
+    X_CSI_SPEC_REQ_VALIDATION
+        A flag that enables the validation of CSI request messages.
+
+    X_CSI_SPEC_REP_VALIDATION
+        A flag that enables the validation of CSI response messages.
+        Invalid responses are marshalled into a gRPC error with a code
+        of "Internal."
 
     X_CSI_REQUIRE_NODE_ID
         A flag that enables treating the following fields as required:
             * ControllerPublishVolumeRequest.NodeId
             * GetNodeIDResponse.NodeId
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_PUB_VOL_INFO
         A flag that enables treating the following fields as required:
             * ControllerPublishVolumeResponse.PublishVolumeInfo
             * NodePublishVolumeRequest.PublishVolumeInfo
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_VOL_ATTRIBS
         A flag that enables treating the following fields as required:
@@ -126,7 +135,7 @@ GLOBAL OPTIONS
             * ValidateVolumeCapabilitiesRequest.VolumeAttributes
             * NodePublishVolumeRequest.VolumeAttributes
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_CREDS
         Setting X_CSI_REQUIRE_CREDS=true is the same as:
@@ -137,43 +146,43 @@ GLOBAL OPTIONS
             X_CSI_REQUIRE_CREDS_NODE_PUB_VOL=true
             X_CSI_REQUIRE_CREDS_NODE_UNPUB_VOL=true
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_CREDS_CREATE_VOL
         A flag that enables treating the following fields as required:
             * CreateVolumeRequest.UserCredentials
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_CREDS_DELETE_VOL
         A flag that enables treating the following fields as required:
             * DeleteVolumeRequest.UserCredentials
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_CREDS_CTRLR_PUB_VOL
         A flag that enables treating the following fields as required:
             * ControllerPublishVolumeRequest.UserCredentials
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_CREDS_CTRLR_UNPUB_VOL
         A flag that enables treating the following fields as required:
             * ControllerUnpublishVolumeRequest.UserCredentials
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_CREDS_NODE_PUB_VOL
         A flag that enables treating the following fields as required:
             * NodePublishVolumeRequest.UserCredentials
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_REQUIRE_CREDS_NODE_UNPUB_VOL
         A flag that enables treating the following fields as required:
             * NodeUnpublishVolumeRequest.UserCredentials
 
-        Enabling this option sets X_CSI_SPEC_VALIDATION=true.
+        Enabling this option sets X_CSI_SPEC_REQ_VALIDATION=true.
 
     X_CSI_SERIAL_VOL_ACCESS
         A flag that enables the serial volume access middleware.


### PR DESCRIPTION
# Necessary and Important
This is a necessary and important change. An SP is capable of making changes to an underlying storage platform. The results of such changes are reflected in CSI response messages. Dropping these messages could render a client unable to acknowledge a change has occurred, and could potentially lead to further errors, such as data loss. This change enables response message validation while still allowing CSI clients to reconstitute the response data, even when it is marked in error.

# Patch Notes
This patch updates the way GoCSI's specification validation middleware handles response validation:

* Validating response messages against the CSI specification now is now   disabled by default. Use `X_CSI_SPEC_REP_VALIDATION=true` to enable  response validation.
* When enabled, response validation no longer drops the response message. Instead the message is encoded into a gRPC error's `Details` field and the error code is set to `Internal`.

The test `With Invalid Plug-in Name Error` in the file `./testing/identity_test.go` demonstrates how to reconstitute the response data on the client-side when the server-side middleware marks the response as invalid.
