### PR TITLE
Update Err Code for Pending Op to Aborted

### DIFF
--- a/middleware/serialvolume/serial_volume_locker.go
+++ b/middleware/serialvolume/serial_volume_locker.go
@@ -113,7 +113,7 @@ func (i *interceptor) controllerPublishVolume(
 		defer closer.Close()
 	}
 	if !lock.TryLock(i.opts.timeout) {
-		return nil, status.Error(codes.FailedPrecondition, pending)
+		return nil, status.Error(codes.Aborted, pending)
 	}
 	defer lock.Unlock()
 
@@ -134,7 +134,7 @@ func (i *interceptor) controllerUnpublishVolume(
 		defer closer.Close()
 	}
 	if !lock.TryLock(i.opts.timeout) {
-		return nil, status.Error(codes.FailedPrecondition, pending)
+		return nil, status.Error(codes.Aborted, pending)
 	}
 	defer lock.Unlock()
 
@@ -155,7 +155,7 @@ func (i *interceptor) createVolume(
 		defer closer.Close()
 	}
 	if !lock.TryLock(i.opts.timeout) {
-		return nil, status.Error(codes.FailedPrecondition, pending)
+		return nil, status.Error(codes.Aborted, pending)
 	}
 	defer lock.Unlock()
 
@@ -176,7 +176,7 @@ func (i *interceptor) deleteVolume(
 		defer closer.Close()
 	}
 	if !lock.TryLock(i.opts.timeout) {
-		return nil, status.Error(codes.FailedPrecondition, pending)
+		return nil, status.Error(codes.Aborted, pending)
 	}
 	defer lock.Unlock()
 
@@ -197,7 +197,7 @@ func (i *interceptor) nodePublishVolume(
 		defer closer.Close()
 	}
 	if !lock.TryLock(i.opts.timeout) {
-		return nil, status.Error(codes.FailedPrecondition, pending)
+		return nil, status.Error(codes.Aborted, pending)
 	}
 	defer lock.Unlock()
 
@@ -218,7 +218,7 @@ func (i *interceptor) nodeUnpublishVolume(
 		defer closer.Close()
 	}
 	if !lock.TryLock(i.opts.timeout) {
-		return nil, status.Error(codes.FailedPrecondition, pending)
+		return nil, status.Error(codes.Aborted, pending)
 	}
 	defer lock.Unlock()
 

--- a/testing/controller_test.go
+++ b/testing/controller_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Controller", func() {
 		err error) bool {
 
 		if err != nil {
-			Ω(err).Should(ΣCM(codes.FailedPrecondition, "pending"))
+			Ω(err).Should(ΣCM(codes.Aborted, "pending"))
 			return true
 		}
 


### PR DESCRIPTION
This patch updates the error code for pending operations returned by the serial volume access middleware to use Aborted instead of FailedPrecondition.

Related to container-storage-interface/spec#160.