### PR TITLE
golang/dep version upgrade to 0.4.1

### DIFF
--- a/gocsi.sh
+++ b/gocsi.sh
@@ -304,7 +304,7 @@ dep_init() {
       GOHOSTARCH=${GOHOSTARCH:-$(echo "$GOVERSION" | awk -F/ '{print $2}')}
     fi
     DEP=./dep
-    DEP_VER=${DEP_VER:-0.3.2}
+    DEP_VER=${DEP_VER:-0.4.1}
     DEP_BIN=${DEP_BIN:-dep-$GOHOSTOS-$GOHOSTARCH}
     DEP_URL=https://github.com/golang/dep/releases/download/v$DEP_VER/$DEP_BIN
     echo "  downloading golang/dep@v$DEP_VER"


### PR DESCRIPTION
A new version of dep was released recently with a lot of improvements. Let's upgrade to 0.4.1.