### PR TITLE
Update CSI-SP Dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # download the dep binary.
 /dep
 /.dep/
+/vendor/github.com/golang/dep
 
 # The ginkgo test binary
 /ginkgo

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ jobs:
       - stage:   test
         env:     JOB=csi-sp
         go:      1.9.3
-        before_install: make dep
         install:        make -C csc
         script:         make csi-sp
 


### PR DESCRIPTION
This patch updates the way dep is downloaded. Now dep's source tree is cloned into vendor and built from there using the forked version of dep with support for GH pull request commits.